### PR TITLE
fix item exporter

### DIFF
--- a/cli/polygonetl/streaming/item_exporter_creator.py
+++ b/cli/polygonetl/streaming/item_exporter_creator.py
@@ -101,6 +101,7 @@ def create_item_exporter(output, testnet, chain_id):
         from blockchainetl.jobs.exporters.kafka_exporter import KafkaItemExporter
         from blockchainetl.jobs.exporters.converters.chain_id_converter import ChainIdConverter
         item_exporter = KafkaItemExporter(output, item_type_to_topic_mapping=TESTNET_KAFKA_TOPIC_MAPPING, converters=[ChainIdConverter(chain_id)]) if testnet else KafkaItemExporter(output, item_type_to_topic_mapping=DEFAULT_KAFKA_TOPIC_MAPPING, converters=[ChainIdConverter(chain_id)])
+    else:
         raise ValueError('Unable to determine item exporter type for output ' + output)
 
     return item_exporter


### PR DESCRIPTION
copy pasta errors introduced from https://github.com/BitskiCo/polygon-etl/pull/11

I could test the Console exporter on local docker which didn't catch this bug. Need better integration testing plan 